### PR TITLE
Adds class changes aligned with time of day

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,35 +1,61 @@
 // Variable
 // Times
-var nine = document.querySelector("#hour-9");
-var ten = document.querySelector("#hour-10");
-var eleven = document.querySelector("#hour-11");
-var twelve = document.querySelector("#hour-12");
-var one = document.querySelector("#hour-1");
-var two = document.querySelector("#hour-2");
-var three = document.querySelector("#hour-3");
-var four = document.querySelector("#hour-4");
-var five = document.querySelector("#hour-5");
+var nineBlock = document.querySelector("#hour-09");
+var tenBlock = document.querySelector("#hour-10");
+var elevenBlock = document.querySelector("#hour-11");
+var twelveBlock = document.querySelector("#hour-12");
+var oneBlock = document.querySelector("#hour-13");
+var twoBlock = document.querySelector("#hour-14");
+var threeBlock = document.querySelector("#hour-15");
+var fourBlock = document.querySelector("#hour-16");
+// var fiveBlock = document.querySelector("#hour-5");
 
-// Set current date
-var date = document.querySelector("#currentDay");
-var today = dayjs();
-$(date).text(today.format('dddd, MMM D, YYYY'));
+// Adding Events
+var textArea = document.querySelectorAll("#description");
+var saveBtn = document.querySelector(".saveBtn");
+var hourBlocks = document.querySelectorAll(".time-block");
 
 
 // Wrap all code that interacts with the DOM in a call to jQuery to ensure that the code isn't run until the browser has finished rendering all the elements in the html.
 $(function () {
-    // TODO: Add a listener for click events on the save button. This code should use the id in the containing time-block as a key to save the user input in local storage. HINT: What does `this` reference in the click listener function? How can DOM traversal be used to get the "hour-x" id of the time-block containing the button that was clicked? How might the id be useful when saving the description in local storage?
+// TODO: Add a listener for click events on the save button. This code should use the id in the containing time-block as a key to save the user input in local storage. HINT: What does `this` reference in the click listener function? How can DOM traversal be used to get the "hour-x" id of the time-block containing the button that was clicked? How might the id be useful when saving the description in local storage?
+
+// Save buttons save events added to page
 
 
 
-    // TODO: Add code to apply the past, present, or future class to each time block by comparing the id to the current hour. HINTS: How can the id attribute of each time-block be used to conditionally add or remove the past, present, and future classes? How can Day.js be used to get the current hour in 24-hour time?
+// TODO: Add code to apply the past, present, or future class to each time block by comparing the id to the current hour. HINTS: How can the id attribute of each time-block be used to conditionally add or remove the past, present, and future classes? How can Day.js be used to get the current hour in 24-hour time? :]
+
+// change past pres future classes for hour blocks using day.js
+
+var checkHour = dayjs().format('HH');
+
+$(hourBlocks).each(function() {
+  var timeValue = $(this).attr("id").split("-")[1];
+
+  if (checkHour == timeValue) {
+    $(this).removeClass('past');
+    $(this).removeClass('future');
+  } else if (checkHour < timeValue) {
+    $(this).removeClass('present');
+    $(this).removeClass('past');
+    $(this).addClass('future');
+  } else if (checkHour > timeValue) {
+    $(this).removeClass('future');
+    $(this).removeClass('present');
+    $(this).addClass('past');
+  };
+});
+ 
+  // TODO: Add code to get any user input that was saved in localStorage and set the values of the corresponding textarea elements. HINT: How can the id attribute of each time-block be used to do this?
 
 
 
-    // TODO: Add code to get any user input that was saved in localStorage and set the values of the corresponding textarea elements. HINT: How can the id attribute of each time-block be used to do this?
-
-
-
-    // TODO: Add code to display the current date in the header of the page.
-  });
+  // TODO: Add code to display the current date in the header of the page. :]
+  // Set current date
+  
+  var date = document.querySelector("#currentDay");
+  var today = dayjs();
+  $(date).text(today.format('dddd, MMMM D, YYYY'));
+});
   

--- a/index.html
+++ b/index.html
@@ -29,11 +29,8 @@
       <p id="currentDay" class="lead"></p>
     </header>
     <div class="container-lg px-5">
-      <!-- Use class for "past", "present", and "future" to apply styles to the time-block divs accordingly. The javascript will need to do this by adding/removing these classes on each div by comparing the hour in the id to the current hour. The html provided below is meant to be an example demonstrating how the css provided can be leveraged to create the desired layout and colors. The html below should be removed or updated in the finished product. Remember to delete this comment once the code is implemented.
-        -->
-
-      <!-- Example of a past time block. The "past" class adds a gray background color. -->
-      <div id="hour-9" class="row time-block past">
+      
+      <div id="hour-09" class="row time-block past present future">
         <div class="col-2 col-md-1 hour text-center py-3">9AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -41,8 +38,7 @@
         </button>
       </div>
 
-      <!-- Example of a a present time block. The "present" class adds a red background color. -->
-      <div id="hour-10" class="row time-block present">
+      <div id="hour-10" class="row time-block past present future">
         <div class="col-2 col-md-1 hour text-center py-3">10AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -50,8 +46,7 @@
         </button>
       </div>
 
-      <!-- Example of a future time block. The "future" class adds a green background color. -->
-      <div id="hour-11" class="row time-block future">
+      <div id="hour-11" class="row time-block past present future">
         <div class="col-2 col-md-1 hour text-center py-3">11AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -59,7 +54,7 @@
         </button>
       </div>
 
-      <div id="hour-12" class="row time-block">
+      <div id="hour-12" class="row time-block past present future">
         <div class="col-2 col-md-1 hour text-center py-3">12PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -67,7 +62,7 @@
         </button>
       </div>
 
-      <div id ="hour-1" class="row time-block">
+      <div id ="hour-13" class="row time-block past present future">
         <div class="col-2 col-md-1 hour text-center py-3">1PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -75,7 +70,7 @@
         </button>
       </div>
 
-      <div id ="hour-2" class="row time-block">
+      <div id ="hour-14" class="row time-block past present future">
         <div class="col-2 col-md-1 hour text-center py-3">2PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -83,7 +78,7 @@
         </button>
       </div>
 
-      <div id ="hour-3" class="row time-block">
+      <div id ="hour-15" class="row time-block past present future">
         <div class="col-2 col-md-1 hour text-center py-3">3PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -91,16 +86,8 @@
         </button>
       </div>
 
-      <div id ="hour-4" class="row time-block">
+      <div id ="hour-16" class="row time-block past present future">
         <div class="col-2 col-md-1 hour text-center py-3">4PM</div>
-        <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
-        <button class="btn saveBtn col-2 col-md-1" aria-label="save">
-          <i class="fas fa-save" aria-hidden="true"></i>
-        </button>
-      </div>
-
-      <div id ="hour-5" class="row time-block">
-        <div class="col-2 col-md-1 hour text-center py-3">5PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>


### PR DESCRIPTION
This PR adds code to the JS file that applies different classes to each time block depending on the time of day (using dayjs) to represent past, present, and future. It also removes the hour-5 div because if the standard work day is 9-5, then you are not scheduling work for 5 o'clock. Also, the other hour ids were changed to follow military time because that is how hours are counted with dayjs.